### PR TITLE
Ensuring that PulMetadataServices::PulfaRecord::Attributes#title does not parse the breadcrumbs from PULFA XML Documents

### DIFF
--- a/lib/pul_metadata_services/pulfa_record.rb
+++ b/lib/pul_metadata_services/pulfa_record.rb
@@ -36,10 +36,15 @@ module PulMetadataServices
 
       class Attributes
         attr_reader :data
+
+        # Constructor
+        # @param data [Nokogiri::XML::Node]
         def initialize(data)
           @data = data
         end
 
+        # Generate the Hash of metadata attributes for the resource
+        # @return [Hash]
         def attributes
           {
             title: title,
@@ -55,48 +60,58 @@ module PulMetadataServices
           }
         end
 
+        # Retrieve the title for the resource
+        # @return [Array<String>]
         def title
-          [ [ breadcrumbs, unittitle_element.text ].reject(&:empty?).join(' - ') ].map { |s| s.gsub(/\s+/, ' ') }
+          [ unittitle_element.text.gsub(/\s+/, ' ') ]
         end
 
-        # look for a component title; if not found look for a collection title
-        def unittitle_element
-          data.at_xpath("#{data_root}/did/unittitle")
-        end
-
+        # Retrieve the IETF language tag for the resource
+        # @return [String]
         def language
           text(data.at_xpath("#{data_root}/did/langmaterial/language/@langcode"))
         end
 
-        def normalized_date
-          text(data.at_xpath("#{data_root}/did/unitdate/@normal"))
-        end
-
+        # Retrieve the human-readable date string for the resource
+        # @return [String]
         def display_date
           text(data.at_xpath("#{data_root}/did/unitdate"))
         end
 
-        def location_code
-          text(data.at_xpath("#{data_root}/did/physloc"))
+        # Retrieve the normalized date for the resource
+        # @return [String]
+        def normalized_date
+          text(data.at_xpath("#{data_root}/did/unitdate/@normal"))
         end
 
-        def container
-          [ [container_parent, container_element('box'), container_element('folder')].compact.join(', ') ]
-        end
-
+        # Retrieve the physical extent for the resource
+        # @return [String]
         def extent
           text(data.at_xpath("#{data_root}/did/physdesc/extent"))
         end
 
-        def component_creators
-          # TODO
+        # Retrieve the physical containers encoded for the resource
+        # e. g. items encoded as having been stored in a box or folder
+        # @return [Array<String>]
+        def container
+          [ [container_parent, container_element('box'), container_element('folder')].compact.join(', ') ]
         end
 
-        def breadcrumbs
-          crumbs = data.xpath("#{data_root}/context/breadcrumbs/crumb")
-          crumbs.map(&:text).compact.join(' - ')
+        # Retrieve the location code for the resource
+        # @return [String]
+        def location_code
+          text(data.at_xpath("#{data_root}/did/physloc"))
         end
 
+        # Retrieve the creator information encoded for the collection in which the item is stored
+        # @return [Array<String>]
+        def collection_creators
+          cres = data.xpath("#{data_root}/context/collectionInfo/collection-creators/*")
+          cres.map(&:content).map(&:strip)
+        end
+
+        # Retrieve the title and identifier information encoded for the collection in which the item is stored
+        # @return [Array<Hash>]
         def collections
           [{
             title: data.at_xpath("#{data_root}/context/collectionInfo/unittitle").content,
@@ -104,34 +119,58 @@ module PulMetadataServices
           }]
         end
 
-        def collection_creators
-          cres = data.xpath("#{data_root}/context/collectionInfo/collection-creators/*")
-          cres.map(&:content).map(&:strip)
+        def component_creators
+          # TODO
         end
 
         def collection_date
           # TODO
         end
 
-        def data_root
-          '/c'
-        end
+        private
 
-        def text(result)
-          [ result.text ] if result
-        end
+          # look for a component title; if not found look for a collection title
+          # @return [Nokogiri::XML::Node]
+          def unittitle_element
+            data.at_xpath("#{data_root}/did/unittitle")
+          end
 
-        def container_parent
-          parent_id = data.at_xpath("/c/did/container/@parent")
-          return unless parent_id
-          parent = data.at_xpath("//c[@id='#{parent_id}']/did/container")
-          "#{parent.attribute('type').value.capitalize} #{parent.content}"
-        end
+          # Retrieve additional information about the title encoded for the resource
+          # @return [String]
+          def breadcrumbs
+            crumbs = data.xpath("#{data_root}/context/breadcrumbs/crumb")
+            crumbs.map(&:text).compact.join(' - ')
+          end
 
-        def container_element(type)
-          val = text(data.at_xpath("/c/did/container[@type='#{type}']"))
-          "#{type.capitalize} #{val.first}" if val
-        end
+          # Generate the XPath used in the Document for retrieving structural metadata
+          # @return [String]
+          def data_root
+            '/c'
+          end
+
+          # Retrieve the text from an XML Element
+          # @param result [Nokogiri::XML::Node]
+          # @return [Array<String>]
+          def text(result)
+            [ result.text ] if result
+          end
+
+          # Generate a description of the parent container for the item (using an encoded ID)
+          # @return [String]
+          def container_parent
+            parent_id = data.at_xpath("/c/did/container/@parent")
+            return unless parent_id
+            parent = data.at_xpath("//c[@id='#{parent_id}']/did/container")
+            "#{parent.attribute('type').value.capitalize} #{parent.content}"
+          end
+
+          # Generate a description of the parent container for the item (using an encoded container type)
+          # @param type [String]
+          # @return [String]
+          def container_element(type)
+            val = text(data.at_xpath("/c/did/container[@type='#{type}']"))
+            "#{type.capitalize} #{val.first}" if val
+          end
       end
 
       class CollectionAttributes < Attributes

--- a/spec/pul_metadata_services/pulfa_record_spec.rb
+++ b/spec/pul_metadata_services/pulfa_record_spec.rb
@@ -14,7 +14,7 @@ describe PulMetadataServices::PulfaRecord do
   describe '#attributes' do
     it 'works' do
       expected = {
-        title: ['Series 1: University Librarian Records - Subseries 1A, Frederic Vinton - Correspondence - 19th Century Catalog and Correspondence, Pre-Vinton, 1811-'],
+        title: ['19th Century Catalog and Correspondence, Pre-Vinton, 1811-'],
         created: ['1865-01-01T00:00:00Z/1865-12-31T23:59:59Z'],
         creator: ['Princeton University. Library. Dept. of Rare Books and Special Collections'],
         publisher: ['Princeton University. Library. Dept. of Rare Books and Special Collections'],


### PR DESCRIPTION
Resolves https://github.com/pulibrary/figgy/issues/1444